### PR TITLE
travis-ciのosxのversionが上がった？ことによりビルド失敗していた問題を修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 os:
   - osx
+osx_image: xcode7.1
 cache:
   directories:
     - "$HOME/.ivy2/cache"
@@ -9,6 +10,7 @@ cache:
     - "$HOME/Library/texlive/2016basic/texmf-var/luatex-cache"
 before_install:
   - brew update
+  - brew install python
   - sudo pip install --upgrade pip
 install:
   - curl -L -O http://mirrors.concertpass.com/tex-archive/systems/mac/mactex/BasicTeX.pkg


### PR DESCRIPTION
公式ページに以下のような表があったので、一つ前のOS 10.10で、最新のものを指定

https://docs.travis-ci.com/user/osx-ci-environment/#OS-X-Version

```
osx_image: xcode8          Xcode 8gm        OS X 10.11
osx_image: xcode7.3        Xcode 7.3.1      OS X 10.11
osx_image: xcode7.2        Xcode 7.2.1      OS X 10.11
osx_image: xcode7.1        Xcode 7.1.1 GM   OS X 10.10
osx_image: xcode7          Xcode 7.0.1 GM   OS X 10.10
osx_image: xcode6.4        Xcode 6.4        OS X 10.10
osx_image: beta-xcode6.3   Xcode 6.3.1      OS X 10.10
osx_image: beta-xcode6.2   Xcode 6.2        OS X 10.9
osx_image: beta-xcode6.1   Xcode 6.1        OS X 10.9
```

以下のようなエラーになったので `brew install python` を追加

```
$ sudo pip install --upgrade pip
sudo: pip: command not found
```

fix https://github.com/dwango/scala_text_pdf/issues/2
