### PR TITLE
TeXLiveのインストール方法を変更

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,13 @@ before_install:
   - brew update
   - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/install-tex.sh
   - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/tlmgr.sh
-  - chmod +x install-tex.sh tlmgr.sh
+  - wget https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt
+  - chmod +x install-tex.sh tlmgr.sh sbt
 install:
   - . ./install-tex.sh
   - ./tlmgr.sh update --self --all || echo "ignore errors"
   - ./tlmgr.sh install latexmk collection-luatex collection-langjapanese collection-fontsrecommended filehook type1cm mdframed needspace fncychap
-  - brew install pandoc sbt
+  - brew install pandoc
   - brew cask install inkscape
   - sudo pip install --upgrade pip
   - sudo pip install pandocfilters

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ cache:
     - "$HOME/Library/texlive/2016basic/texmf-var/luatex-cache"
 before_install:
   - brew update
-  - sudo pip install --upgrade pip
+  - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/install-tex.sh
+  - wget https://raw.githubusercontent.com/y-yu/install-tex-travis/master/tlmgr.sh
+  - chmod +x install-tex.sh tlmgr.sh
 install:
-  - curl -L -O http://mirrors.concertpass.com/tex-archive/systems/mac/mactex/BasicTeX.pkg
-  - sudo installer -pkg BasicTeX.pkg -target /
-  - rm BasicTeX.pkg
-  - export PATH=$PATH:/usr/texbin
-  - sudo tlmgr update --self --all
-  - sudo tlmgr install latexmk collection-luatex collection-langjapanese collection-fontsrecommended filehook type1cm mdframed needspace fncychap
+  - . ./install-tex.sh
+  - ./tlmgr.sh update --self --all || echo "ignore errors"
+  - ./tlmgr.sh install latexmk collection-luatex collection-langjapanese collection-fontsrecommended filehook type1cm mdframed needspace fncychap
   - brew install pandoc sbt
   - brew cask install inkscape
+  - sudo pip install --upgrade pip
   - sudo pip install pandocfilters
 before_script:
   - sudo mkdir -p /usr/local/texlive/2016basic/texmf-local/fonts/opentype/public/hiragino/

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 set -e
 
 cd ./scala_text
-sbt tut
+../sbt tut
 cd -
 cp ./scala_text/book.json ./
 cp -r ./scala_text/src/img ./


### PR DESCRIPTION
Fix #2 

Travis CIのOSXのバージョン変更によりTeXLiveのPATHが変更されたのでCIが落ちるようになった。よい機会なので、今まで自前でやっていたTeXLiveのインストールを専用のインストールスクリプト（[install-tex-travis](https://github.com/y-yu/install-tex-travis)）を用いるように変更した。
