### PR TITLE
Update LuaLaTeX cache path for TeXLive 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
     - "$HOME/.ivy2/cache"
     - "$HOME/.sbt/boot"
     - "$HOME/.sbt/launchers"
-    - "$HOME/texlive/2017/texmf-var/luatex-cache"
+    - "$HOME/texlive/texmf-var/luatex-cache"
     - "$HOME/.ghc"
     - "$HOME/.cabal"
     - "$HOME/.local"


### PR DESCRIPTION
- TeXLive 2018がリリースされたため、[install-tex-travis](https://github.com/y-yu/install-tex-travis)をアップデートした
- それにより、フォントキャッシュのパスが変更されたため、その対応をした